### PR TITLE
Update to version of OP2Utility that does not require Windows.h

### DIFF
--- a/ConsoleArgumentParser.cpp
+++ b/ConsoleArgumentParser.cpp
@@ -25,7 +25,7 @@ bool ConsoleArgumentParser::FindSwitch(char* argumentChar, ConsoleSwitch& curren
 		argument.pop_back();
 	}
 
-	for (ConsoleSwitch consoleSwitch : consoleSwitches)
+	for (const auto& consoleSwitch : consoleSwitches)
 	{
 		if (consoleSwitch.ArgumentMatch(argument)) {
 			currentSwitch = consoleSwitch;

--- a/ConsoleArgumentParser.h
+++ b/ConsoleArgumentParser.h
@@ -30,7 +30,7 @@ class ConsoleArgumentParser
 		std::function<void(const char*, ConsoleArgs&)> parseFunction;
 		int numberOfArgs; // The switch statement itself does not count as an argument.
 
-		bool ArgumentMatch(std::string argument)
+		bool ArgumentMatch(const std::string& argument) const
 		{
 			return argument == shortSwitch || argument == longSwitch;
 		}

--- a/Main.cpp
+++ b/Main.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <iostream>
 #include <stdexcept>
+#include <cstddef>
 #include "Timer.h"
 
 using namespace std;
@@ -36,7 +37,7 @@ int main(int argc, char **argv)
 		//if (!consoleArgs.renderSettings.quiet)
 		//    cout << "Map Renders completed in " << timer.GetElapsedTime() << " seconds.";
 	}
-	catch (exception e) {
+	catch (const std::exception& e) {
 		cerr << e.what() << endl;
 		cerr << "Run without arguments to see usage message." << endl << endl;
 
@@ -62,7 +63,7 @@ void ExecuteCommand(const ConsoleArgs& consoleArgs)
 		throw runtime_error("You must provide at least one file or directory. To provide the current directory, enter './'.");
 	}
 
-	for (string path : consoleArgs.paths)
+	for (const auto& path : consoleArgs.paths)
 	{
 		if (XFile::IsDirectory(path)) {
 			ImageMapsInDirectoryFromConsole(path, consoleArgs.renderSettings);
@@ -100,9 +101,10 @@ void ImageMapsInDirectoryFromConsole(const string& directory, RenderSettings ren
 	
 	filenames.insert(std::end(filenames), std::begin(saveFilenames), std::end(saveFilenames));
 
-	for (size_t i = filenames.size() - 1; i >= 0; i--)
+	// Loop starts at index size - 1 and ends after index 0 executes
+	for (std::size_t i = filenames.size(); i-- > 0; )
 	{
-		string filename = XFile::GetFilename(filenames[i]);
+		string& filename = XFile::GetFilename(filenames[i]);
 		if (filename == "wellpallet.map") {
 			filenames.erase(filenames.begin() + i);
 		}
@@ -118,7 +120,7 @@ void ImageMapsInDirectoryFromConsole(const string& directory, RenderSettings ren
 		cout << consoleLineBreak << endl << endl;
 	}
 
-	for (string filename : filenames) {
+	for (const auto& filename : filenames) {
 		ImageMapFromConsole(filename, renderSettings);
 	}
 

--- a/MapImager.cpp
+++ b/MapImager.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <cstddef>
 
 using namespace std;
 
@@ -10,8 +11,7 @@ bool MapImager::ImageMap(string& renderFilenameOut, const string& filename, cons
 {
 	bool saveGame = IsSavedGame(filename);
 
-	MapReader mapReader;
-	MapData mapData = mapReader.Read(resourceManager.GetResourceStream(filename, renderSettings.accessArchives), saveGame);
+	MapData mapData = MapReader::Read(*resourceManager.GetResourceStream(filename, renderSettings.accessArchives), saveGame);
 
 	RenderManager::Initialize();
 
@@ -93,7 +93,7 @@ string MapImager::CreateUniqueFilename(const string& filename)
 
 void MapImager::LoadTilesets(MapData& mapData, RenderManager& mapImager, bool accessArchives)
 {
-	for (size_t i = 0; i < mapData.tilesetSources.size(); ++i)
+	for (std::size_t i = 0; i < mapData.tilesetSources.size(); ++i)
 	{
 		if (mapData.tilesetSources[i].numTiles == 0) {
 			continue;
@@ -119,14 +119,14 @@ void MapImager::LoadTilesets(MapData& mapData, RenderManager& mapImager, bool ac
 
 void MapImager::SetRenderTiles(MapData& mapData, RenderManager& renderManager)
 {
-	for (unsigned int y = 0; y < mapData.header.mapTileHeight; y++) {
-		for (unsigned int x = 0; x < mapData.header.MapTileWidth(); x++) {
+	for (unsigned int y = 0; y < mapData.header.mapTileHeight; ++y) {
+		for (unsigned int x = 0; x < mapData.header.MapTileWidth(); ++x) {
 			renderManager.PasteTile(mapData.GetTilesetIndex(x, y), mapData.GetImageIndex(x, y), x, y);
 		}
 	}
 }
 
-bool MapImager::IsSavedGame(string filename)
+bool MapImager::IsSavedGame(const string& filename)
 {
 	return XFile::ExtensionMatches(filename, ".OP2");
 }

--- a/MapImager.h
+++ b/MapImager.h
@@ -29,5 +29,5 @@ private:
 	void LoadTilesets(MapData& mapData, RenderManager& mapImager, bool accessArchives);
 	std::string FormatRenderFilename(const std::string& filename, const RenderSettings& renderSettings);
 	std::string CreateUniqueFilename(const std::string& filename);
-	bool IsSavedGame(std::string filename);
+	bool IsSavedGame(const std::string& filename);
 };

--- a/OP2MapImager.sln
+++ b/OP2MapImager.sln
@@ -18,16 +18,16 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Debug|x64.ActiveCfg = Debug|x64
-		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Debug|x64.Build.0 = Debug|x64
+		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Debug|x64.ActiveCfg = Debug|Win32
+		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Debug|x64.Build.0 = Debug|Win32
 		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Debug|x86.ActiveCfg = Debug|Win32
 		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Debug|x86.Build.0 = Debug|Win32
 		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Release|x64.ActiveCfg = Release|x64
 		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Release|x64.Build.0 = Release|x64
 		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Release|x86.ActiveCfg = Release|Win32
 		{C2D3BC8B-BC2D-40C6-8B59-9E9B449B73FC}.Release|x86.Build.0 = Release|Win32
-		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x64.ActiveCfg = Debug|x64
-		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x64.Build.0 = Debug|x64
+		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x64.ActiveCfg = Debug|Win32
+		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x64.Build.0 = Debug|Win32
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x86.ActiveCfg = Debug|Win32
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Debug|x86.Build.0 = Debug|Win32
 		{980D53D9-F9E2-4682-9307-1303C9E42313}.Release|x64.ActiveCfg = Release|x64
@@ -37,5 +37,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B41D4D0E-59B9-4C34-8118-BE045B7A440E}
 	EndGlobalSection
 EndGlobal

--- a/OP2MapImager.vcxproj
+++ b/OP2MapImager.vcxproj
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>OP2Utility\Archives;OP2Utility;FreeImage\Dist\x32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>OP2Utiliy\Maps;OP2Utility\Archives;OP2Utility;FreeImage\Dist\x32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>

--- a/RenderManager.cpp
+++ b/RenderManager.cpp
@@ -30,7 +30,7 @@ RenderManager::RenderManager(int mapTileWidth, int mapTileHeight, int bpp, int s
 
 RenderManager::~RenderManager() 
 {
-	for (FIBITMAP* fiBmp : tilesetBmps) {
+	for (auto* fiBmp : tilesetBmps) {
 		FreeImage_Unload(fiBmp);
 	}
 


### PR DESCRIPTION
Prepare source code for better compatibility with Linux compilers.

 - Make calls to size_t Clang compiler consistent
 - Update for loops to used ranged based loops where appropriate
 - Update range based for loops to use auto keyword where appropriate
 - Update range based for loops to use const references where appropriate
 - Update for loops to place unary operators as prefixes
 - Remove x64 references from VS solution

Closes #1 
Closes #2 (I did not actually find any offending calls to string.c_str in OP2MapImager)
Closes #4 
Closes #5 

Plan to update ConsoleArgumentParser to match OP2Archive in a separate branch.
