### PR TITLE
Add Linux makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Debug
 MapRenders
 Release
 *.user
+.build/

--- a/makefile
+++ b/makefile
@@ -11,17 +11,17 @@ BUILDDIR := .build
 BINDIR := $(BUILDDIR)/bin
 OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
-OUTPUT := $(BINDIR)/op2archive
+OUTPUT := $(BINDIR)/op2mapimager
 
 CFLAGS := -std=c++14 -g -Wall -Wno-unknown-pragmas -I OP2Utility/
-LDFLAGS := -lstdc++ -lm -lstdc++fs
+LDFLAGS := -lstdc++ -lm -lstdc++fs -lfreeimage
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 
 COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CFLAGS) $(TARGET_ARCH) -c
 POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
 
-SRCS := $(shell find $(SRCDIR) -name '*.cpp')
+SRCS := $(shell find $(SRCDIR) -name '*.cpp' -not -path './FreeImage/*')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(OBJDIR)/%.o,$(SRCS))
 FOLDERS := $(sort $(dir $(SRCS)))
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,56 @@
+
+# Set compiler default
+# Can still override from command line or environment variables
+# Example: make CXX=clang
+ifeq ($(origin CXX),default)
+	CXX := clang-6.0
+endif
+
+SRCDIR := .
+BUILDDIR := .build
+BINDIR := $(BUILDDIR)/bin
+OBJDIR := $(BUILDDIR)/obj
+DEPDIR := $(BUILDDIR)/deps
+OUTPUT := $(BINDIR)/op2archive
+
+CFLAGS := -std=c++14 -g -Wall -Wno-unknown-pragmas -I OP2Utility/
+LDFLAGS := -lstdc++ -lm -lstdc++fs
+
+DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
+
+COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CFLAGS) $(TARGET_ARCH) -c
+POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
+
+SRCS := $(shell find $(SRCDIR) -name '*.cpp')
+OBJS := $(patsubst $(SRCDIR)/%.cpp,$(OBJDIR)/%.o,$(SRCS))
+FOLDERS := $(sort $(dir $(SRCS)))
+
+all: $(OUTPUT)
+
+$(OUTPUT): $(OBJS)
+	@mkdir -p ${@D}
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+$(OBJS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp $(DEPDIR)/%.d | build-folder
+	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
+	$(POSTCOMPILE)
+
+.PHONY:build-folder
+build-folder:
+	@mkdir -p $(patsubst $(SRCDIR)/%,$(OBJDIR)/%, $(FOLDERS))
+	@mkdir -p $(patsubst $(SRCDIR)/%,$(DEPDIR)/%, $(FOLDERS))
+
+$(DEPDIR)/%.d: ;
+.PRECIOUS: $(DEPDIR)/%.d
+
+include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(DEPDIR)/%.d,$(SRCS)))
+
+.PHONY:clean, clean-deps, clean-all
+clean:
+	-rm -fr $(OBJDIR)
+	-rm -fr $(DEPDIR)
+	-rm -fr $(BINDIR)
+clean-deps:
+	-rm -fr $(DEPDIR)
+clean-all:
+	-rm -rf $(BUILDDIR)


### PR DESCRIPTION
Note: To install the FreeImage library and development headers on Ubuntu, run:
```
sudo apt install libfreeimage-dev
```

This touches on Issue #7.
