### PR TITLE
Fix crash when unable to find map file

### DIFF
--- a/src/MapImager.cpp
+++ b/src/MapImager.cpp
@@ -11,7 +11,14 @@ bool MapImager::ImageMap(string& renderFilenameOut, const string& filename, cons
 {
 	bool saveGame = IsSavedGame(filename);
 
-	MapData mapData = MapReader::Read(*resourceManager.GetResourceStream(filename, renderSettings.accessArchives), saveGame);
+	std::unique_ptr<SeekableStreamReader> mapStream = resourceManager.GetResourceStream(filename, renderSettings.accessArchives);
+
+	if (mapStream == nullptr) {
+		cerr << "Unable to locate " + filename + " within directory or within an archive (vol or clm) in the directory." << endl << endl;
+		return false;
+	}
+
+	MapData mapData = MapReader::Read(*mapStream, saveGame);
 
 	RenderManager::Initialize();
 


### PR DESCRIPTION
This may fix #11. Even if the bug is separate, it is still a major bug. 

Also, this file as LF only line endings.