### PR TITLE
Fix bug preventing rendering maps from archives.

### DIFF
--- a/src/MapImager.cpp
+++ b/src/MapImager.cpp
@@ -131,8 +131,8 @@ MapData MapImager::ReadMap(const string& filename, bool accessArchives)
 	}
 
 	if (XFile::ExtensionMatches(filename, ".OP2")) {
-		return MapReader::ReadSavedGame(filename);
+		return MapReader::ReadSavedGame(*mapStream);
 	}
 	
-	return MapReader::ReadMap(filename);
+	return MapReader::ReadMap(*mapStream);
 }


### PR DESCRIPTION
Closes #21 

OP2MapImager should allow rendering a map from an archive without unpacking it. Wells (tilesets) will still be unpacked from archives before being referenced.

Thanks Dan for teasing this bug out for me.