### PR TITLE
Fix CircleCI submodule checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
       - image: outpostuniverse/circleci-gcc-googletest-freeimage
     steps:
       - checkout
-      - run: git submodule init
-      - run: git submodule update --remote
+      - run: git submodule update --init
       - run: make -k CXX=g++
       - run: make check CXX=g++


### PR DESCRIPTION
Previously, it was updating submodules to the most recent version of the branch, rather than using the recorded SHA-1 hash. This made builds unreliable, as they were not always building with the intended submodule version.
