### PR TITLE
Switch to order only dependency for OP2Utility

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,11 +32,9 @@ FOLDERS := $(sort $(dir $(SRCS)))
 
 all: $(OUTPUT)
 
-$(OUTPUT): $(UTILITYLIB) $(OBJS)
+$(OUTPUT): $(OBJS) | op2utility
 	@mkdir -p ${@D}
 	$(CXX) $^ $(LDFLAGS) -o $@ $(LDLIBS)
-
-$(UTILITYLIB): op2utility
 
 .PHONY:op2utility
 op2utility:


### PR DESCRIPTION
This is a Linux only Makefile change.

Previously, the OP2MapImager project depended directly on the library file for OP2Utility. That means any updates to OP2Utility static library would cause OP2MapImager to be rebuilt. However, the OP2MapImager makefile did not have rules to determine if the OP2Utility static library was up to date. Those rules were contained in the makefile for OP2Utility. Hence the OP2MapImager project could sometimes build with an out of date / wrong / previous version of the OP2Utility static library.

By switching to an order only dependency (for a PHONY rule), the OP2MapImager makefile will always attempt to rebuild OP2Utility, and so will always run the OP2Utility makefile. This ensures the OP2Utility static library will be kept up to date with the submodule source. It also remains efficient, as the OP2Utility knows the dependency information for the static library, and so will only rebuild it when it needs to. This should ensure proper building as each stage of the build now uses proper dependency information.

Note: This change only affects builds that had a previous version of OP2Utility already compiled. As the CI builds always use a fresh checkout, they never encountered this particular case.
