### PR TITLE
Target C++17 instead of C++14

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ UTILITYDIR := OP2Utility
 UTILITYLIB := $(UTILITYDIR)/lib$(UTILITYBASE).a
 
 CPPFLAGS := -I $(UTILITYDIR)/include
-CXXFLAGS := -std=c++14 -g -Wall -Wno-unknown-pragmas
+CXXFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas
 LDFLAGS := -L$(UTILITYDIR)
 LDLIBS := -l$(UTILITYBASE) -lstdc++fs -lstdc++ -lm -lfreeimage
 


### PR DESCRIPTION
This silences some warnings about the `constexpr-if` statements recently added to OP2Utility's stream code for zero cost checks for signed/unsigned negative values.
